### PR TITLE
Add CI workflow and community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Report a problem with the website
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for taking the time to file a bug. Please fill out the details below.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the issue?
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Public website
+        - Admin panel
+        - Authentication
+        - Other / not sure
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Browser, OS, device, and screen size if relevant.
+      placeholder: "Chrome 124 on Windows 11, desktop"
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or console output
+      description: Drag-and-drop screenshots or paste any console errors.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Alievs-corp/alievsspacemmc/security/advisories/new
+    about: Please report security issues privately — do not open a public issue.
+  - name: General questions / contact
+    url: mailto:info@alievsspace.com
+    about: For general questions, email the team.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this solve, or what would it improve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you would like to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you've considered.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Public website
+        - Admin panel
+        - Design system
+        - Other
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+<!-- Thanks for your contribution! Please fill out the sections below. -->
+
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / style
+- [ ] Documentation
+- [ ] Chore / tooling
+
+## Checklist
+
+- [ ] Branched off `main` with a descriptive, prefixed branch name
+- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] `npm run build` passes (in `frontend/`)
+- [ ] `npm run lint` reviewed (no new errors)
+- [ ] UI changes use design tokens / shared component classes (no hardcoded hex/px)
+- [ ] User-facing strings are translated (en / az / ru)
+
+## Screenshots
+
+<!-- For UI changes, add before/after screenshots. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend (lint + build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Reported but non-blocking while existing lint debt is cleared.
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Type-check & build
+        run: npm run build

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,39 @@
+# Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in this
+project a respectful and welcoming experience for everyone, regardless of
+background, identity, or level of experience.
+
+## Our standards
+
+Behavior that contributes to a positive environment includes:
+
+- Being respectful of differing viewpoints and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the project and the community
+- Showing empathy and kindness toward other people
+
+Unacceptable behavior includes any form of harassment, personal attacks,
+insulting or derogatory comments, intimidation, or publishing other people's
+private information without their explicit permission.
+
+## Scope
+
+This Code of Conduct applies within all project spaces (the repository, issues,
+pull requests, and discussions) and when an individual is representing the project
+in public spaces.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers at
+**info@alievsspace.com**. All reports will be reviewed and investigated promptly
+and fairly. Maintainers are responsible for clarifying and enforcing these
+standards and may take appropriate corrective action, including editing or
+removing contributions or restricting participation.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant
+(https://www.contributor-covenant.org).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,77 @@
+# Contributing
+
+Thanks for contributing to the Alievs Space MMC website. This repository tracks
+the **company website frontend** (in `frontend/`) plus repository documentation.
+The backend API and the academy app live in separate repositories.
+
+## Prerequisites
+
+- **Node.js 20.19+ or 22.12+** and **npm**
+- Git
+
+## Getting started
+
+```bash
+cd frontend
+npm install
+cp .env.example .env   # then set VITE_API_URL
+npm run dev
+```
+
+Environment variables:
+
+- `VITE_API_URL` — base URL of the API (e.g. `http://localhost:8080/api/v1`).
+- `VITE_BASE_PATH` — Vite `base` path, only needed for sub-path hosting.
+
+## Available scripts (run inside `frontend/`)
+
+| Command | Description |
+| ------- | ----------- |
+| `npm run dev` | Start the Vite dev server |
+| `npm run build` | Type-check (`tsc`) and build for production |
+| `npm run lint` | Run ESLint |
+| `npm run preview` | Preview the production build |
+
+> There is no test runner configured yet. Verify changes with `npm run build`
+> and the dev server.
+
+## Workflow
+
+1. **Branch off `main`.** Never commit directly to `main`.
+   Use a descriptive, prefixed branch name, e.g. `feat/blog-page`,
+   `fix/contact-form`, `chore/ci`.
+2. **Make focused commits** using
+   [Conventional Commits](https://www.conventionalcommits.org/):
+   - `feat:` a new feature
+   - `fix:` a bug fix
+   - `refactor:` / `style:` / `chore:` / `docs:` / `test:`
+   - Example: `feat(home): wire hero to API content`
+3. **Before pushing**, make sure the build is green:
+   ```bash
+   cd frontend && npm run build && npm run lint
+   ```
+4. **Open a Pull Request against `main`** and fill in the PR template.
+   Keep PRs small and scoped; link any related issues.
+5. A maintainer reviews and merges once CI passes.
+
+## Code style
+
+- **Styling:** Tailwind CSS v4. Use the semantic design tokens defined in
+  `frontend/src/index.css` (`bg-bg`, `bg-surface`, `text-primary`,
+  `border-border`, `font-display`, …) and the shared component classes
+  (`.card`, `.panel`, `.field`). **Do not hardcode hex colors or ad-hoc px
+  values** in components.
+- Use the `cn()` helper (`@/lib/utils`) to compose class names.
+- Prefer **Lucide** icons; keep one icon set per surface.
+- Keep components typed; avoid `any`.
+- All user-facing UI strings should go through the i18n helper `t()` and exist
+  for `en`, `az`, and `ru`.
+
+## Reporting issues
+
+Use the issue templates (Bug report / Feature request). For **security
+vulnerabilities**, follow [SECURITY.md](./SECURITY.md) — do not open a public
+issue.
+
+By contributing, you agree that your contributions are the property of Alievs
+Space MMC under the repository [LICENSE](./LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2026 Alievs Space MMC. All rights reserved.
+
+PROPRIETARY AND CONFIDENTIAL
+
+This software, including all source code, assets, and documentation in this
+repository (the "Software"), is the proprietary and confidential property of
+Alievs Space MMC (the "Company").
+
+The Software is provided solely for authorized internal development and operation
+of the Company's products and services. No license, right, or permission is
+granted to any person or entity to use, copy, modify, merge, publish, distribute,
+sublicense, sell, or create derivative works of the Software, in whole or in part,
+without the prior express written consent of the Company.
+
+Unauthorized copying, reproduction, distribution, or use of the Software, via any
+medium, is strictly prohibited and may violate applicable copyright, trade secret,
+and other laws.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE COMPANY OR
+ITS CONTRIBUTORS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+For licensing inquiries, contact: info@alievsspace.com

--- a/README.md
+++ b/README.md
@@ -1,30 +1,84 @@
-# Alievs Space MMC
+# Alievs Space MMC — Company Website
 
-## About Alievs Space MMC
+[![CI](https://github.com/Alievs-corp/alievsspacemmc/actions/workflows/ci.yml/badge.svg)](https://github.com/Alievs-corp/alievsspacemmc/actions/workflows/ci.yml)
 
-**Alievs Space MMC** is a technology company specializing in the design and development of modern software solutions. We combine innovation, technical expertise, and reliability to deliver products that meet the highest standards of performance and scalability.
+The official website of **Alievs Space MMC**, a technology company building modern,
+scalable software products. This repository contains the **company website
+frontend** (in `frontend/`) and repository documentation. The backend API and the
+academy app are maintained in separate repositories.
 
-### About Us
+## Tech stack
 
-At Alievs Space, we develop and maintain our own software products and also collaborate with partner companies to deliver custom projects. Our team ensures that every project is completed efficiently, on time, and with a strong focus on quality and long-term sustainability.
+- **Vite 7** + **React 18** + **TypeScript**
+- **React Router 7**
+- **Tailwind CSS v4** (design tokens via `@theme` in `src/index.css`)
+- **Lucide** icons
+- Hand-rolled i18n (`en` / `az` / `ru`)
 
-### Areas of Expertise
+## Getting started
 
-- **Web Solutions:** Scalable and secure web applications
-- **Mobile Applications:** Native and cross-platform development
-- **APIs and Backend Systems:** High-performance, maintainable architectures
-- **Real-Time Communication Systems:** Low-latency, reliable communication tools
-- **Infrastructure and DevOps:** Complete deployment and cloud management solutions
+```bash
+cd frontend
+npm install
+cp .env.example .env   # then set VITE_API_URL
+npm run dev
+```
 
-### Technologies
+Environment variables:
 
-We use modern, industry-proven technologies and continuously evolve with emerging trends: Go, Python, Java, JavaScript, TypeScript, Rust, Flask, FastAPI, Gin, Echo, React, Next.js, Flutter, PostgreSQL, Redis, Docker, AWS, WebSockets, and more.
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `VITE_API_URL` | Base URL of the API | `http://localhost:8080/api/v1` |
+| `VITE_BASE_PATH` | Vite `base` path (sub-path hosting only) | — |
 
-### Our Commitment
+### Scripts (run inside `frontend/`)
 
-We are dedicated to building solutions that are not only functional but also maintainable, efficient, and adaptable to future needs. Our mission is to help businesses grow through technology.
+| Command | Description |
+| ------- | ----------- |
+| `npm run dev` | Start the Vite dev server |
+| `npm run build` | Type-check (`tsc`) and build for production |
+| `npm run lint` | Run ESLint |
+| `npm run preview` | Preview the production build |
+
+## Project structure
+
+```
+.
+├── frontend/            # Company website (Vite + React + Tailwind) — tracked here
+│   ├── src/
+│   │   ├── components/   # Layout, UI, and admin components
+│   │   ├── pages/        # Public pages + admin panel (/admin/*)
+│   │   ├── contexts/     # i18n, auth, content providers
+│   │   └── lib/          # API client, i18n, utilities
+│   └── ...
+├── .github/             # CI workflow, issue/PR templates
+└── README.md
+```
+
+> The backend API (`alievsspacemmc-api`) and academy app (`alievsspace-academy`)
+> live in their own repositories.
+
+## Contributing
+
+Contributions follow a feature-branch + Pull Request workflow with
+[Conventional Commits](https://www.conventionalcommits.org/). See
+[CONTRIBUTING.md](./CONTRIBUTING.md) and the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Security
+
+Please report vulnerabilities privately — see [SECURITY.md](./SECURITY.md). Do not
+open public issues for security problems.
+
+## License
+
+Proprietary — © Alievs Space MMC. All rights reserved. See [LICENSE](./LICENSE).
 
 ---
 
-**Alievs Space MMC** — Building premium digital products that scale.
+### About Alievs Space MMC
 
+We specialize in the design and development of modern software solutions — web and
+mobile applications, APIs and backend systems, real-time communication, and
+DevOps/infrastructure — combining innovation, technical expertise, and reliability.
+
+**Alievs Space MMC** — Building premium digital products that scale.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+We take the security of Alievs Space MMC's website and systems seriously.
+
+## Supported versions
+
+Only the latest code on the `main` branch (and the live production deployment) is
+supported with security updates.
+
+| Version | Supported |
+| ------- | --------- |
+| `main` (latest) | ✅ |
+| older commits / tags | ❌ |
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Instead, report privately using either of the following:
+
+1. **GitHub private vulnerability reporting** — open the repository's
+   **Security** tab → **Report a vulnerability** (preferred), or
+2. **Email** — send details to **info@alievsspace.com** with the subject line
+   `SECURITY`.
+
+Please include, where possible:
+
+- A description of the vulnerability and its potential impact.
+- Steps to reproduce (proof-of-concept, affected URL/endpoint, payload).
+- The affected component (website, admin panel, API integration, etc.).
+- Any suggested remediation.
+
+## What to expect
+
+- We aim to **acknowledge** your report within **3 business days**.
+- We will investigate, keep you updated on progress, and notify you when the
+  issue is resolved.
+- Please give us a reasonable period to remediate before any public disclosure.
+
+We appreciate responsible disclosure and will credit reporters who wish to be
+acknowledged.


### PR DESCRIPTION
Adds continuous integration and the standard GitHub community health files.

## CI
- `.github/workflows/ci.yml` — runs on pushes to `main` and on PRs:
  - `npm ci` in `frontend/`
  - `npm run lint` (reported, non-blocking while existing lint debt is cleared)
  - `npm run build` (type-check + production build) as the gate

## Community health files
- **README** — refreshed with stack, setup, scripts, structure, and links (plus a CI badge); kept the company overview.
- **LICENSE** — proprietary, © Alievs Space MMC, all rights reserved.
- **CODE_OF_CONDUCT.md** — adapted from the Contributor Covenant; reports to `info@alievsspace.com`.
- **CONTRIBUTING.md** — setup, feature-branch + Conventional Commits workflow, code-style/design-token rules.
- **SECURITY.md** — private reporting (GitHub advisories + `info@alievsspace.com`), supported versions, response time.
- **Issue templates** — bug report + feature request (issue forms) and `config.yml` (disables blank issues, routes security/contact).
- **Pull request template**.

## Not done via files (require repo Settings — admin action)
- **Description** — set the repo's "About" description in **Settings** (it's repo metadata, not a file).
- **Repository admins accept content reports** — enable under **Settings → Moderation options → Reported content**.